### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,69 @@ on:
       - master
 
 jobs:
-  build-docker:
+  build-java:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven
+      - name: Build with Maven
+        run: mvn -B package
+      - name: Upload alerting-storm jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: alerting-storm
+          path: alerting/alerting-storm/target/alerting-storm-*.jar
+      - name: Upload enriching-storm jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: enriching-storm
+          path: enriching/enriching-storm/target/enriching-storm-*.jar
+      - name: Upload parsing-storm jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: parsing-storm
+          path: parsing/parsing-storm/target/parsing-storm-*.jar
+
+  build-docker-storm:
+    runs-on: ubuntu-latest
+    needs: build-java
+    strategy:
+      matrix:
+        component: [alerting-storm, enriching-storm, parsing-storm]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download jar
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.component }}
+          path: deployment/docker
+      - name: Get component info
+        id: info
+        run: |
+          [xml]$xml = Get-Content ./*/${{ matrix.component}}/pom.xml
+          echo "::set-output name=version::$($xml.project.parent.version)"
+          echo "::set-output name=class::$($xml.project.build.plugins.plugin.executions.execution.configuration.transformers.transformer.mainClass)"
+        shell: pwsh
       - name: Build and push Docker image
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: gresearchdev/siembol
-          dockerfile: deployment/docker/Dockerfile
-          tag_with_ref: true
-          tag_with_sha: true
-          add_git_labels: true
+          repository: gresearchdev/siembol-${{ matrix.component }}
+          path: deployment/docker
+          dockerfile: deployment/docker/Dockerfile.storm
+          build_args: JAR=${{ matrix.component }}-${{ steps.info.outputs.version }}.jar,CLASS=${{ steps.info.outputs.class }}
           always_pull: true
+          add_git_labels: true
+          tags: latest,${{ steps.info.outputs.version }}

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM mcr.microsoft.com/java/maven:8-zulu-debian9 as build
-WORKDIR /src/siembol
-COPY . .
-RUN mvn package && rm /src/siembol/*/*/target/original-*.jar
-
-
-FROM storm:1.2.3
-WORKDIR /deploy
-COPY --from=build /src/siembol/*/*-storm/target/*-storm-*.jar ./

--- a/deployment/docker/Dockerfile.storm
+++ b/deployment/docker/Dockerfile.storm
@@ -1,0 +1,10 @@
+FROM storm:1.2.3
+
+ARG JAR
+ARG CLASS
+ENV TOPOLOGY_JAR=$JAR
+ENV TOPOLOGY_CLASS=$CLASS
+
+WORKDIR /deploy
+COPY $TOPOLOGY_JAR .
+COPY storm-entrypoint.sh /docker-entrypoint.sh

--- a/deployment/docker/storm-entrypoint.sh
+++ b/deployment/docker/storm-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# if command starts with something that is not executable, prepend our deploy command
+if ! which "${1}" >/dev/null; then
+  set -- storm -c nimbus.seeds="${NIMBUS_SEEDS:-"[\"nimbus\"]"}" jar $TOPOLOGY_JAR $TOPOLOGY_CLASS "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
* Split the CI into build-java and build-docker-storm jobs
* Separate Docker images are built for each Storm component
* Docker images are tagged with the version number as read from pom.xml
* A Docker entrypoint is added to ease deployment