### PR TITLE
Make the hero text pop a little more

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -31,7 +31,11 @@
 }
 
 h1.text-brand-main-color {
-    color: #00AAE1 !important;
+    color: #fff !important;
+}
+
+.col-lg-12.white h1 a {
+    color: #fff !important;
 }
 
 /* FEATURES */


### PR DESCRIPTION
I felt like the text over the hero image was getting lost in the background, so trying a change to white.

I also changed the `h1` in the footer to white to match.