### PR TITLE
Use GitHub Actions Environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,16 @@
 name: CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build-java:
+    # Do not run this job for pull requests where both branches are from the same repo.
+    # Jobs that depend on this one will be skipped too.
+    # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
+    # run the CI for each branch push to a fork, and for each pull request originating from a fork.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -88,17 +95,12 @@ jobs:
         shell: pwsh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Generate Docker labels
         id: labels
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: gresearchdev/siembol-${{ matrix.component }}
-      - name: Build and push Docker image
+      - name: Build and export Docker image
         uses: docker/build-push-action@v2
         with:
           context: deployment/docker
@@ -107,7 +109,7 @@ jobs:
             JAR=${{ matrix.component }}-${{ steps.info.outputs.version }}.jar
             CLASS=${{ steps.info.outputs.class }}
           pull: true
-          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          outputs: type=docker,dest=image.tar
           tags: |
             gresearchdev/siembol-${{ matrix.component }}:latest
             gresearchdev/siembol-${{ matrix.component }}:${{ steps.info.outputs.version }}
@@ -115,6 +117,11 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-${{ matrix.component }}
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-${{ matrix.component }}
+          path: image.tar
 
   build-docker-java:
     runs-on: ubuntu-latest
@@ -151,17 +158,12 @@ jobs:
         shell: pwsh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Generate Docker labels
         id: labels
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: gresearchdev/siembol-${{ matrix.component }}
-      - name: Build and push Docker image
+      - name: Build and export Docker image
         uses: docker/build-push-action@v2
         with:
           context: deployment/docker
@@ -170,7 +172,7 @@ jobs:
             APP=${{ matrix.component}}
             VERSION=${{ steps.info.outputs.version }}
           pull: true
-          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          outputs: type=docker,dest=image.tar
           tags: |
             gresearchdev/siembol-${{ matrix.component }}:latest
             gresearchdev/siembol-${{ matrix.component }}:${{ steps.info.outputs.version }}
@@ -178,8 +180,18 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-${{ matrix.component }}
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-${{ matrix.component }}
+          path: image.tar
 
   build-js-config-editor-ui:
+    # Do not run this job for pull requests where both branches are from the same repo.
+    # Jobs that depend on this one will be skipped too.
+    # This prevents duplicate CI runs for our own pull requests, whilst preserving the ability to
+    # run the CI for each branch push to a fork, and for each pull request originating from a fork.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -233,23 +245,18 @@ jobs:
         run: echo "::set-output name=version::$(jq -r .appVersion deployment/docker/config-editor-ui/assets/build-info.json)"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Generate Docker labels
         id: labels
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: gresearchdev/siembol-config-editor-ui
-      - name: Build and push Docker image
+      - name: Build and export Docker image
         uses: docker/build-push-action@v2
         with:
           context: deployment/docker
           file: deployment/docker/Dockerfile.config-editor-ui
           pull: true
-          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          outputs: type=docker,dest=image.tar
           tags: |
             gresearchdev/siembol-config-editor-ui:latest
             gresearchdev/siembol-config-editor-ui:${{ steps.info.outputs.version }}
@@ -257,12 +264,18 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-config-editor-ui
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-config-editor-ui
+          path: image.tar
 
   release-version:
+    # Only run this job for master and hotfix branches.
+    # Jobs that depend on this one will be skipped too.
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
     runs-on: ubuntu-latest
     needs: build-java
-    # we only release from master or tags
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -278,10 +291,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: release-version
-    # deploy only SNAPSHOT versions from master and non-SNAPSHOTs from tags
-    if: >
-      github.ref == 'refs/heads/master' && endsWith(needs.release-version.outputs.version, '-SNAPSHOT') ||
-      startsWith(github.ref, 'refs/tags/') && ! endsWith(needs.release-version.outputs.version, '-SNAPSHOT')
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -312,3 +322,29 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+
+  release-docker:
+    # Only run this job for master and hotfix branches.
+    # Jobs that depend on this one will be skipped too.
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+    runs-on: ubuntu-latest
+    needs: [build-docker-storm, build-docker-java, build-docker-config-editor-ui]
+    environment: release
+    strategy:
+      matrix:
+        component: [alerting-storm, enriching-storm, parsing-storm, config-editor-rest, responding-stream, storm-topology-manager, config-editor-ui]
+      fail-fast: false
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Download Docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-${{ matrix.component }}
+      - name: Load Docker image
+        run: docker load --input image.tar
+      - name: Publish Docker image
+        run: docker push gresearchdev/siembol-${{ matrix.component }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,9 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-${{ matrix.component }}
+      # Only run this step for master and hotfix branches.
       - name: Upload Docker image
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-${{ matrix.component }}
@@ -180,7 +182,9 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-${{ matrix.component }}
+      # Only run this step for master and hotfix branches.
       - name: Upload Docker image
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-${{ matrix.component }}
@@ -264,7 +268,9 @@ jobs:
             ${{ steps.labels.outputs.labels }}
             org.opencontainers.image.version=${{ steps.info.outputs.version }}
             org.opencontainers.image.title=siembol-config-editor-ui
+      # Only run this step for master and hotfix branches.
       - name: Upload Docker image
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-config-editor-ui


### PR DESCRIPTION
This PR secures our release workflow by using [GitHub Actions Environments](https://docs.github.com/en/actions/reference/environments) to ensure that the release secrets can only be accessed by the `master` and `hotfix/*` branches.

It also changes our CI to run for pull requests originating from forked repos.

Fixes #47.