### PR TITLE
Stackedsax add quickstart

### DIFF
--- a/deployment/minikube/minikube.sh
+++ b/deployment/minikube/minikube.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+profile=siembol
+
+echo == install prerequisites ==
+brew install helm kubernetes-cli minikube mkcert nss
+
+echo == create and install CA ==
+mkcert -install
+
+echo == create k8s cluster ==
+minikube start --profile $profile --driver hyperkit --container-runtime containerd --cni calico --cpus 4 --memory 4g --disk-size 40g --addons ingress,ingress-dns
+minikube profile $profile
+
+echo == add DNS resolver ==
+sudo mkdir -p /etc/resolver
+sudo tee /etc/resolver/minikube-$(minikube profile) >/dev/null << EOF
+domain $(minikube profile).local
+nameserver $(minikube ip)
+search_order 1
+timeout 5
+EOF
+
+echo == install cert-manager ==
+helm repo add jetstack https://charts.jetstack.io
+kubectl create namespace cert-manager
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --set installCRDs=true
+
+
+printf '== wait for cert-manager to be up'
+for deployment in cert-manager cert-manager-cainjector cert-manager-webhook
+do
+  while ! [ "$(kubectl get deployment $deployment --namespace cert-manager -o jsonpath='{.status.readyReplicas}')" == "1" ]; do printf .; sleep 1; done
+done
+echo ' =='
+
+
+echo == install CA in siembol namespace ==
+kubectl create namespace $profile
+kubectl create -n $profile secret tls cacerts --cert=$HOME/Library/ApplicationSupport/mkcert/rootCA.pem --key=$HOME/Library/ApplicationSupport/mkcert/rootCA-key.pem
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+  namespace: $profile
+spec:
+  ca:
+    secretName: cacerts
+EOF
+
+
+
+

--- a/docs/introduction/how-tos/quickstart.md
+++ b/docs/introduction/how-tos/quickstart.md
@@ -54,7 +54,7 @@ Install Siembol in the cluster:
 
 ```bash
 helm repo add gresearch https://g-research.github.io/charts
-helm upgrade --install siembol -n siembol -f deployment/helm/config-editor/values.yaml gresearch/siembol
+helm upgrade --install siembol -n siembol -f https://raw.githubusercontent.com/G-Research/charts/0ac159d72a4fe842e3034834c3e8a9f7a5b47989/src/siembol/quickstart-values.yaml gresearch/siembol
 ```
 
 ## Cleaning up

--- a/docs/introduction/how-tos/quickstart.md
+++ b/docs/introduction/how-tos/quickstart.md
@@ -1,0 +1,75 @@
+# Look! Docs!
+# Quickstart Guide
+
+## Local Install
+### Minikube
+
+#### 1. Run minikube.sh
+
+```bash
+deployment/minikube/minikube.sh
+```
+
+#### 2. Prepare Siembol Config Repository
+
+##### 1. Fork Siembol Config Repository
+
+1. Go to https://github.com/stackedsax/siembol-config
+   * Ask for access if you don't have it already
+1. Fork into your own organization or personal account
+
+#### 2. Update application.properties
+
+Edit `deployment/helm/config-editor/resources/application.properties`
+
+Change <your_github_username> in these lines: 
+
+```
+config-editor.services.alert.config-store.git-user-name=<your_github_username>
+config-editor.services.alert.config-store.store-repository-name=<your_github_username>/siembol-config
+config-editor.services.alert.config-store.release-repository-name=<your_github_username>/siembol-config
+```
+
+#### 3. Prepare git
+
+##### 1. Create Git Secret
+
+Generate a token
+1. Go to https://github.com/settings/tokens
+2. Click Generate Token
+4. Select "repo - Full control of private repositories" scope
+5. Hit "Generate token"
+6. Copy token value to a file named `git_token`
+
+##### 2. Generate a secret for your git API Token:
+
+This creates a Kubernetes secret for the Config Editor to interact with git.
+
+```bash
+kubectl create secret generic siembol-config-editor-rest-secrets --from-file=git_token -n siembol
+```
+
+
+
+#### 4. Helm install
+
+Install Siembol in the cluster:
+
+```bash
+helm repo add gresearch https://g-research.github.io/charts
+helm upgrade --install siembol -n siembol -f deployment/helm/config-editor/values.yaml deployment/helm/config-editor
+```
+
+### Cleaning up
+If you're done poking about on a local instance, you can clean up with:
+
+```bash
+minikube delete -p siembol
+sudo rm /etc/resolver/minikube-*
+```
+
+## Cloud Install
+
+### GCE
+
+### Amazon

--- a/docs/introduction/how-tos/quickstart.md
+++ b/docs/introduction/how-tos/quickstart.md
@@ -1,38 +1,37 @@
-# Look! Docs!
-# Quickstart Guide
+Quickstart Guide
+================
 
-## Local Install
-### Minikube
+Local Install
+----------------
 
-#### 1. Run minikube.sh
+### 1. Run minikube.sh
 
 ```bash
 deployment/minikube/minikube.sh
 ```
 
-#### 2. Prepare Siembol Config Repository
+### 2. Prepare Siembol Config Repository
 
-##### 1. Fork Siembol Config Repository
+#### 1. Fork Siembol Config Repository
 
-1. Go to https://github.com/stackedsax/siembol-config
-   * Ask for access if you don't have it already
+1. Go to https://github.com/G-Research/siembol-config
 1. Fork into your own organization or personal account
 
 #### 2. Update application.properties
 
 Edit `deployment/helm/config-editor/resources/application.properties`
 
-Change <your_github_username> in these lines: 
+Change <your_github_org_or_username> in these lines: 
 
 ```
-config-editor.services.alert.config-store.git-user-name=<your_github_username>
-config-editor.services.alert.config-store.store-repository-name=<your_github_username>/siembol-config
-config-editor.services.alert.config-store.release-repository-name=<your_github_username>/siembol-config
+config-editor.services.alert.config-store.git-user-name=<your_github_org_or_username>
+config-editor.services.alert.config-store.store-repository-name=<your_github_org_or_username>/siembol-config
+config-editor.services.alert.config-store.release-repository-name=<your_github_org_or_username>/siembol-config
 ```
 
-#### 3. Prepare git
+### 3. Prepare git
 
-##### 1. Create Git Secret
+#### 1. Create Git Secret
 
 Generate a token
 1. Go to https://github.com/settings/tokens
@@ -41,7 +40,7 @@ Generate a token
 5. Hit "Generate token"
 6. Copy token value to a file named `git_token`
 
-##### 2. Generate a secret for your git API Token:
+#### 2. Generate a secret for your git API Token:
 
 This creates a Kubernetes secret for the Config Editor to interact with git.
 
@@ -49,27 +48,19 @@ This creates a Kubernetes secret for the Config Editor to interact with git.
 kubectl create secret generic siembol-config-editor-rest-secrets --from-file=git_token -n siembol
 ```
 
-
-
-#### 4. Helm install
+### 4. Helm install
 
 Install Siembol in the cluster:
 
 ```bash
 helm repo add gresearch https://g-research.github.io/charts
-helm upgrade --install siembol -n siembol -f deployment/helm/config-editor/values.yaml deployment/helm/config-editor
+helm upgrade --install siembol -n siembol -f deployment/helm/config-editor/values.yaml gresearch/siembol
 ```
 
-### Cleaning up
+## Cleaning up
 If you're done poking about on a local instance, you can clean up with:
 
 ```bash
 minikube delete -p siembol
 sudo rm /etc/resolver/minikube-*
 ```
-
-## Cloud Install
-
-### GCE
-
-### Amazon

--- a/docs/introduction/how-tos/quickstart.md
+++ b/docs/introduction/how-tos/quickstart.md
@@ -19,7 +19,9 @@ deployment/minikube/minikube.sh
 
 #### 2. Update application.properties
 
-Edit `deployment/helm/config-editor/resources/application.properties`
+1. Clone the https://github.com/G-Research/charts repo
+1. Switch to the `siembol` branch: `git checkout stackedsax/siembol`
+2. Edit: `src/siembol/resources/application.properties`
 
 Change <your_github_org_or_username> in these lines: 
 
@@ -28,6 +30,12 @@ config-editor.services.alert.config-store.git-user-name=<your_github_org_or_user
 config-editor.services.alert.config-store.store-repository-name=<your_github_org_or_username>/siembol-config
 config-editor.services.alert.config-store.release-repository-name=<your_github_org_or_username>/siembol-config
 ```
+
+#### 3. Update git.config
+
+1. Still in the `siembol` repo, edit: `src/siembol/resources/git.config`
+2. Replace "your_username" and "your_email" with the appropriate values
+
 
 ### 3. Prepare git
 
@@ -38,24 +46,35 @@ Generate a token
 2. Click Generate Token
 4. Select "repo - Full control of private repositories" scope
 5. Hit "Generate token"
-6. Copy token value to a file named `git_token`
+6. Copy token value to a file named `git`
 
 #### 2. Generate a secret for your git API Token:
 
 This creates a Kubernetes secret for the Config Editor to interact with git.
 
 ```bash
-kubectl create secret generic siembol-config-editor-rest-secrets --from-file=git_token -n siembol
+kubectl create secret generic siembol-config-editor-rest-secrets --from-file=git -n siembol
 ```
+
 
 ### 4. Helm install
 
-Install Siembol in the cluster:
+To install Siembol in the cluster
 
 ```bash
 helm repo add gresearch https://g-research.github.io/charts
-helm upgrade --install siembol -n siembol -f https://raw.githubusercontent.com/G-Research/charts/0ac159d72a4fe842e3034834c3e8a9f7a5b47989/src/siembol/quickstart-values.yaml gresearch/siembol
+helm upgrade --install siembol -n siembol charts/src/siembol -f charts/src/siembol/quickstart-values.yaml
 ```
+
+This step might take 3-5 minutes depending on the specs of your development machine.
+
+### Check it out!
+
+In a browser, go to:
+
+  * https://ui.siembol.local/home
+
+You should now see the Siembol UI homepage.
 
 ## Cleaning up
 If you're done poking about on a local instance, you can clean up with:


### PR DESCRIPTION
Here's a quickstart guide and a helper script for minikube from Jonathan to test.

Unfortunately, the guide relies on the updated helm chart being available, and that's pending in this PR:
* https://github.com/G-Research/charts/pull/7

So, for now, you'll have to pull the chart down locally and install it.  Instead of step 4:
```bash
helm repo add gresearch https://g-research.github.io/charts
helm upgrade --install siembol -n siembol -f https://raw.githubusercontent.com/G-Research/charts/0ac159d72a4fe842e3034834c3e8a9f7a5b47989/src/siembol/quickstart-values.yaml gresearch/siembol
```

You could just try 
```bash
wget https://github.com/G-Research/charts/blob/0ac159d72a4fe842e3034834c3e8a9f7a5b47989/siembol/siembol-0.1.1.tgz
helm upgrade --install siembol -n siembol -f https://raw.githubusercontent.com/G-Research/charts/0ac159d72a4fe842e3034834c3e8a9f7a5b47989/src/siembol/quickstart-values.yaml siembol-0.1.1.tgz
```
