### PR TITLE
Publish test results fork

### DIFF
--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -16,47 +16,25 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/github-script@v3
-        with:
-          script: |
-            var fs = require('fs');
-            var path = require('path');
-            var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
-            fs.mkdirSync(artifacts_path, { recursive: true })
-
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{ github.event.workflow_run.id }},
-            });
-
-            for (const artifact of artifacts.data.artifacts) {
-               var download = await github.actions.downloadArtifact({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  artifact_id: artifact.id,
-                  archive_format: 'zip',
-               });
-               var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
-               fs.writeFileSync(artifact_path, Buffer.from(download.data));
-               console.log(`Downloaded ${artifact_path}`);
-            }
-      - name: Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in artifacts/*.zip
-          do
-            if [ -f "$file" ]
-            then
-              dir="${file/%.zip/}"
-              mkdir -p "$dir"
-              unzip -d "$dir" "$file"
-            fi
-          done
+          artifact_url=${{ github.event.workflow_run.artifacts_url }}
+          artifact_url=$(gh api $artifact_url -q '.artifacts[] | select(.name=="unit-test-results") .archive_download_url')
+          if [[ -n "$artifact_url" ]]
+          then
+            gh api $artifact_url > unit-test-results.zip
+            unzip unit-test-results.zip
+          else
+            echo "::error::No artifact with name 'unit-test-results' exists"
+            exit 1
+          fi
+        shell: bash
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           check_name: unit-test-results
           comment_title: Unit Test Results
-          files: "artifacts/*/**/*.xml"
+          files: "**/target/surefire-reports/TEST-*.xml"
           commit: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -15,6 +15,9 @@ jobs:
       github.event.workflow_run.head_repository.full_name != github.repository
 
     steps:
+      # we are not using actions/download-artifact here as
+      # it does not support downloading from a different workflow
+      # https://github.com/actions/download-artifact/issues/3
       - name: Download Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -16,14 +16,14 @@ jobs:
 
     steps:
       # we are not using actions/download-artifact here as
-      # it does not support downloading from a different workflow
+      # it does not yet support downloading from a different workflow
       # https://github.com/actions/download-artifact/issues/3
       - name: Download Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          artifact_url=${{ github.event.workflow_run.artifacts_url }}
-          artifact_url=$(gh api $artifact_url -q '.artifacts[] | select(.name=="unit-test-results") .archive_download_url')
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          artifact_url=$(gh api $artifacts_url -q '.artifacts[] | select(.name=="unit-test-results") .archive_download_url')
           if [[ -n "$artifact_url" ]]
           then
             gh api $artifact_url > unit-test-results.zip

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -1,0 +1,62 @@
+name: CI (Fork)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion != 'skipped' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var path = require('path');
+            var artifacts_path = path.join('${{github.workspace}}', 'artifacts')
+            fs.mkdirSync(artifacts_path, { recursive: true })
+
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            for (const artifact of artifacts.data.artifacts) {
+               var download = await github.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip',
+               });
+               var artifact_path = path.join(artifacts_path, `${artifact.name}.zip`)
+               fs.writeFileSync(artifact_path, Buffer.from(download.data));
+               console.log(`Downloaded ${artifact_path}`);
+            }
+      - name: Extract Artifacts
+        run: |
+          for file in artifacts/*.zip
+          do
+            if [ -f "$file" ]
+            then
+              dir="${file/%.zip/}"
+              mkdir -p "$dir"
+              unzip -d "$dir" "$file"
+            fi
+          done
+
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: unit-test-results
+          comment_title: Unit Test Results
+          files: "artifacts/*/**/*.xml"
+          commit: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,19 @@ jobs:
         if: failure()
         run: mvn --batch-mode surefire-report:report-only
       - name: Publish unit test results
-        if: always() && ( github.event_name == 'push' || !github.event.repository.fork )
+        if: >
+          always() &&
+          ( github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id )
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           check_name: unit-test-results
           comment_title: Unit Test Results
           files: "**/target/surefire-reports/TEST-*.xml"
       - name: Upload unit-test-results
-        if: always() && github.event_name == 'pull_request' && github.event.repository.fork
+        if: >
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,18 @@ jobs:
         if: failure()
         run: mvn --batch-mode surefire-report:report-only
       - name: Publish unit test results
+        if: always() && ( github.event_name == 'push' || !github.event.repository.fork )
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           check_name: unit-test-results
           comment_title: Unit Test Results
           files: "**/target/surefire-reports/TEST-*.xml"
+      - name: Upload unit-test-results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-test-results
+          path: "**/target/surefire-reports/TEST-*.xml"
 
       - name: Upload alerting-storm jar
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           comment_title: Unit Test Results
           files: "**/target/surefire-reports/TEST-*.xml"
       - name: Upload unit-test-results
-        if: always()
+        if: always() && github.event_name == 'pull_request' && github.event.repository.fork
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,10 @@ jobs:
         if: failure()
         run: mvn --batch-mode surefire-report:report-only
       - name: Publish unit test results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
+        uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           check_name: unit-test-results
           comment_title: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           files: "**/target/surefire-reports/TEST-*.xml"
 
       - name: Upload alerting-storm jar


### PR DESCRIPTION
Unit test results are not published for PRs coming from forks. This adds the required workflow to support that.

This can only be tested once merged into master as the new `CI (Fork)` workflow runs from the master `.github/workflow/ci-fork.yml` only.