### PR TITLE
Add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/deployment/docker"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/config-editor/config-editor-ui"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-fork.yml
+++ b/.github/workflows/ci-fork.yml
@@ -11,8 +11,10 @@ jobs:
     name: Unit Test Results
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion != 'skipped' &&
-      github.event.workflow_run.head_repository.full_name != github.repository
+      github.event.workflow_run.conclusion != 'skipped' && (
+        github.event.sender.login == 'dependabot[bot]' ||
+        github.event.workflow_run.head_repository.full_name != github.repository
+      )
 
     steps:
       # we are not using actions/download-artifact here as

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Publish unit test results
         if: >
           always() &&
+          github.event.sender.login != 'dependabot[bot]' &&
           ( github.event_name == 'push' || github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id )
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
@@ -43,9 +44,10 @@ jobs:
           files: "**/target/surefire-reports/TEST-*.xml"
       - name: Upload unit-test-results
         if: >
-          always() &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+          always() && (
+            github.event.sender.login == 'dependabot[bot]' ||
+            github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
+          )
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results


### PR DESCRIPTION
How do you think about dependabot support?

https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

It creates PRs that upgrade dependencies, which can be merged with a single PR comment:
https://github.com/EnricoMi/publish-unit-test-result-action/pull/112

The changes to `ci.yml` and `ci-fork.yml` are required because dependabot PRs run like fork PRs isolated from your repository (no access to secrets) because new dependencies can pull in malicious code through those dependencies. Test results cannot be posted to the pull request from the CI workflow that runs the depdendabot PR.