### PR TITLE
Fix releasing of versioned Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,4 +372,4 @@ jobs:
       - name: Load Docker image
         run: docker load --input image.tar
       - name: Publish Docker image
-        run: docker push gresearchdev/siembol-${{ matrix.component }}
+        run: docker push --all-tags gresearchdev/siembol-${{ matrix.component }}


### PR DESCRIPTION
PR #65 broke releasing of versioned Docker images. Only `latest` was pushed, and the versioned tag wasn't.

This PR aims to fix that.