### PR TITLE
do not build on gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on: 
+  push:
+    branches:
+      - "!gh-pages"
 
 jobs:
   build-java:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on: 
   push:
-    branches:
-      - "!gh-pages"
+    branches-ignore:
+      - "gh-pages"
 
 jobs:
   build-java:


### PR DESCRIPTION
Purpose of this PR is to avoid building on the `gh-pages` branch which should be used only for GH pages feature.

Looking at > https://github.com/G-Research/siembol/pull/277 and failing unit tests, this move made sense.