### PR TITLE
Always upload test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,7 @@ jobs:
         if: failure()
         run: mvn --batch-mode surefire-report:report-only
       - name: Upload unit-test-results
-        if: >
-          always() && (
-            github.event.sender.login == 'dependabot[bot]' ||
-            github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
-          )
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: unit-test-results


### PR DESCRIPTION
With the changes in #336 we need to always upload test results. Sorry, that should have been part of that PR.