### PR TITLE
Handle skipped pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,8 @@ jobs:
 
   event_file:
     name: "Event File"
+    needs: build-java
+    if: always() && needs.build-java.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - name: Upload

--- a/.github/workflows/unit-test-results.yml
+++ b/.github/workflows/unit-test-results.yml
@@ -17,6 +17,7 @@ jobs:
       # it does not yet support downloading from a different workflow
       # https://github.com/actions/download-artifact/issues/3
       - name: Download Artifacts
+        id: download
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -31,14 +32,12 @@ jobs:
             unzip -d "$name" "$name.zip"
           done
 
-          if [ $(ls . | wc -l) -eq 0 ]
-          then
-            echo "::error::No artifact with name 'unit-test-results' or 'Event File' exists"
-            exit 1
-          fi
+          echo "Downloaded $(ls . | wc -l) artifacts"
+          echo "::set-output name=artifact-count::$(ls . | wc -l)"
         shell: bash
 
       - name: Publish unit test results
+        if: steps.download.outputs.artifact-count >= 2
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           check_name: unit-test-results


### PR DESCRIPTION
The `pull_request` event is skipped by the CI workflow when it is from this repo (not a fork PR). The `Unit Test Results` workflow should not run in that situation.

That workflow identifies this situation simply by the lack of the event file and any unit test artifact.