### PR TITLE
Updates references to new more inclusive default branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,11 @@ jobs:
         with:
           images: gresearchdev/siembol-${{ matrix.component }}
           flavor: |
-            latest=${{ github.ref == 'refs/heads/master' && !endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
+            latest=${{ github.ref == 'refs/heads/main' && !endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
           # We use raw because our release process is not done on tag push (yet)
           tags: |
             type=raw,value=${{ steps.info.outputs.version }}
-            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/master' && endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
+            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/main' && endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
           labels: |
             org.opencontainers.image.title=siembol-${{ matrix.component }}
       - name: Build and export Docker image
@@ -120,9 +120,9 @@ jobs:
           outputs: type=docker,dest=image.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      # Only run this step for master and hotfix branches.
+      # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-${{ matrix.component }}
@@ -169,11 +169,11 @@ jobs:
         with:
           images: gresearchdev/siembol-${{ matrix.component }}
           flavor: |
-            latest=${{ github.ref == 'refs/heads/master' && !endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
+            latest=${{ github.ref == 'refs/heads/main' && !endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
           # We use raw because our release process is not done on tag push (yet)
           tags: |
             type=raw,value=${{ steps.info.outputs.version }}
-            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/master' && endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
+            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/main' && endsWith(steps.info.outputs.version, '-SNAPSHOT') }}
           labels: |
             org.opencontainers.image.title=siembol-${{ matrix.component }}
       - name: Build and export Docker image
@@ -188,9 +188,9 @@ jobs:
           outputs: type=docker,dest=image.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      # Only run this step for master and hotfix branches.
+      # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-${{ matrix.component }}
@@ -254,11 +254,11 @@ jobs:
         with:
           images: gresearchdev/siembol-config-editor-ui
           flavor: |
-            latest=${{ github.ref == 'refs/heads/master' && !endsWith(steps.info.outputs.version, '-dev') }}
+            latest=${{ github.ref == 'refs/heads/main' && !endsWith(steps.info.outputs.version, '-dev') }}
           # We use raw because our release process is not done on tag push (yet)
           tags: |
             type=raw,value=${{ steps.info.outputs.version }}
-            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/master' && endsWith(steps.info.outputs.version, '-dev') }}
+            type=raw,value=snapshot,enable=${{ github.ref == 'refs/heads/main' && endsWith(steps.info.outputs.version, '-dev') }}
           labels: |
             org.opencontainers.image.title=siembol-config-editor-ui
       - name: Build and export Docker image
@@ -270,18 +270,18 @@ jobs:
           outputs: type=docker,dest=image.tar
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      # Only run this step for master and hotfix branches.
+      # Only run this step for main and hotfix branches.
       - name: Upload Docker image
-        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+        if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
         uses: actions/upload-artifact@v2
         with:
           name: docker-config-editor-ui
           path: image.tar
 
   release-version:
-    # Only run this job for master and hotfix branches.
+    # Only run this job for main and hotfix branches.
     # Jobs that depend on this one will be skipped too.
-    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
     runs-on: ubuntu-latest
     needs: build-java
     outputs:
@@ -333,9 +333,9 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
 
   release-docker:
-    # Only run this job for master and hotfix branches.
+    # Only run this job for main and hotfix branches.
     # Jobs that depend on this one will be skipped too.
-    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/hotfix/') )
+    if: github.event_name == 'push' && !github.event.repository.fork && ( github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/') )
     runs-on: ubuntu-latest
     needs: [build-docker-storm, build-docker-java, build-docker-config-editor-ui]
     environment: release

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   # Run schedule at 04:00 on Monday.
   schedule:
     - cron: '0 4 * * 1' 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ To join the conversation, use this link:
 
 Siembol is licensed with the Apache 2.0 license.  You can find it published here:
 
-* [https://github.com/G-Research/siembol/blob/master/LICENSE](https://github.com/G-Research/siembol/blob/master/LICENSE)
+* [https://github.com/G-Research/siembol/blob/main/LICENSE](https://github.com/G-Research/siembol/blob/main/LICENSE)

--- a/config/config-editor-ui/ui-config.json
+++ b/config/config-editor-ui/ui-config.json
@@ -10,7 +10,7 @@
         {
             "icon": "library_books",
             "title": "Documentation",
-            "link": "https://github.com/G-Research/siembol/tree/master/docs"
+            "link": "https://github.com/G-Research/siembol/tree/main/docs"
         },
         {
             "icon": "live_help",

--- a/docs/siembol_ui/how-tos/how_to_add_links_to_siembol_ui_home_page.md
+++ b/docs/siembol_ui/how-tos/how_to_add_links_to_siembol_ui_home_page.md
@@ -15,7 +15,7 @@ Below is the default config file provided where the two default links are in "ho
                 {
                     "icon": "library_books",
                     "title": "Documentation",
-                    "link": "https://github.com/G-Research/siembol/tree/master/docs"
+                    "link": "https://github.com/G-Research/siembol/tree/main/docs"
                 },
                 {   
                     "icon": "live_help",

--- a/docs/siembol_ui/siembol_ui.md
+++ b/docs/siembol_ui/siembol_ui.md
@@ -30,7 +30,7 @@ Below is the default config file provided. The two default links are in "homeLin
             {
                 "icon": "library_books",
                 "title": "Documentation",
-                "link": "https://github.com/G-Research/siembol/tree/master/docs"
+                "link": "https://github.com/G-Research/siembol/tree/main/docs"
             },
             {   
                 "icon": "live_help",

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.co.gresearch.siembol</groupId>
     <artifactId>siembol</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.co.gresearch.siembol</groupId>
     <artifactId>siembol</artifactId>
@@ -21,7 +20,7 @@
         <connection>scm:git:git://github.com/g-research/siembol.git</connection>
         <developerConnection>scm:git:ssh://github.com:g-research/siembol.git</developerConnection>
         <url>https://github.com/g-research/siembol/tree/${project.scm.tag}</url>
-        <tag>master</tag>
+        <tag>main</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
This PR is preparing to set this repository to create and use main as the default branch as a more inclusive term than the current default. This PR replaces https://github.com/G-Research/siembol/pull/422 due to the need to reserve the branch name.