### PR TITLE
Remove the certmanager version from quickstart script

### DIFF
--- a/deployment/quickstart_install/sh-scripts/minikube.sh
+++ b/deployment/quickstart_install/sh-scripts/minikube.sh
@@ -25,7 +25,7 @@ echo == install cert-manager ==
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --set installCRDs=true
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --set installCRDs=true
 
 
 printf '== wait for cert-manager to be up'


### PR DESCRIPTION
The version of cert-manager specified in the install script generated errors due to known issues in that version https://github.com/jetstack/cert-manager/issues/2817 