### PR TITLE
[quickstart] Fix domain name resolution failures on macOS

### DIFF
--- a/deployment/helm-k8s/values.yaml
+++ b/deployment/helm-k8s/values.yaml
@@ -77,13 +77,13 @@ storm:
 dep_ingresses:
   enrichment_store:
     enabled: true
-    fqdn: enrichment.local
+    fqdn: enrichment.siembol.local
     oauth2_proxy:
       enabled: false
       host: oauth-proxy.siembol.local
   storm:
     enabled: true
-    fqdn: storm.local
+    fqdn: storm.siembol.local
     service:
       name: storm-ui
       port: 8080
@@ -162,7 +162,7 @@ ui:
   # Run with an ingress
   ingress:
     enabled: true
-    fqdn: siembol.local
+    fqdn: ui.siembol.local
 
 
 # -----------------------------------------------------------------------------

--- a/deployment/quickstart_install/ps-scripts/enrichmentStore.ps1
+++ b/deployment/quickstart_install/ps-scripts/enrichmentStore.ps1
@@ -8,7 +8,7 @@ Write-Output '{"1.2.3.4":{"hostname":"test-name"}}' > $FileName
 
 # POST request
 $FilePath = (Get-Location).path + '/' + $FileName
-$URL = 'https://enrichment.local/upload.php';
+$URL = 'https://enrichment.siembol.local/upload.php';
 $boundary = [System.Guid]::NewGuid().ToString(); 
 $LF = "`r`n";
 
@@ -31,7 +31,7 @@ Invoke-RestMethod -Method 'Post' -Uri $restUri -Headers $header -Body ($body|Con
 
 Write-Output "************************************************************"
 Write-Output "Check uploaded table through this url in the browser:"
-Write-Output "https://enrichment.local/download.php?filename=$FileName"
+Write-Output "https://enrichment.siembol.local/download.php?filename=$FileName"
 Write-Output "************************************************************"
 Write-Output "Check siembol table info through this url in the browser:"
 Write-Output "https://rest.siembol.local/api/v1/enrichment/enrichment/tables"

--- a/deployment/quickstart_install/ps-scripts/minikube.ps1
+++ b/deployment/quickstart_install/ps-scripts/minikube.ps1
@@ -12,11 +12,11 @@ minikube start --profile $namespace --driver hyperv --cpus 6 --memory 6g --disk-
 minikube profile $namespace
 
 Write-Output == install dns host entries ==
-Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'siembol.local' -Description 'resolver for siembol.local'
+Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'ui.siembol.local' -Description 'resolver for ui.siembol.local'
 Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'rest.siembol.local' -Description 'resolver for rest.siembol.local'
-Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'storm.local' -Description 'resolver for storm.local'
+Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'storm.siembol.local' -Description 'resolver for storm.siembol.local'
 Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'topology-manager.siembol.local' -Description 'resolver for topology-manager.siembol.local'
-Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'enrichment.local' -Description 'resolver for enrichment.local'
+Set-CHostsEntry -IPAddress $(minikube ip) -HostName 'enrichment.siembol.local' -Description 'resolver for enrichment.siembol.local'
 
 Write-Output == install cert-manager ==
 helm repo add jetstack https://charts.jetstack.io

--- a/deployment/quickstart_install/sh-scripts/enrichmentStore.sh
+++ b/deployment/quickstart_install/sh-scripts/enrichmentStore.sh
@@ -2,13 +2,13 @@ echo "********* Set up demo enrichment table **************"
 echo "*****************************************************"
 
 echo '{"1.2.3.4":{"hostname":"test-name"}}' > hostname.json
-curl -F "uploaded_file=@hostname.json;" https://enrichment.local/upload.php
+curl -F "uploaded_file=@hostname.json;" https://enrichment.siembol.local/upload.php
 
 curl -X 'POST' https://rest.siembol.local/api/v1/enrichment/enrichment/tables -H 'accept: application/json' -H 'Content-Type: application/json' -d '{\"name\": \"hostname\",\"path\": \"/download.php?filename=dns.json\"}'
 
 echo "************************************************************"
 echo "Check uploaded table through this url in the browser:"
-echo "https://enrichment.local/download.php?filename=hostname.json"
+echo "https://enrichment.siembol.local/download.php?filename=hostname.json"
 echo "************************************************************"
 echo "Check siembol table info through this url in the browser:"
 echo "https://rest.siembol.local/api/v1/enrichment/enrichment/tables"

--- a/docs/introduction/how-tos/quickstart.md
+++ b/docs/introduction/how-tos/quickstart.md
@@ -65,11 +65,11 @@ This step might take a few minutes depending on the specs of your development ma
 
 In a browser, go to:
 
-  * https://siembol.local/home
+  * https://ui.siembol.local/home
 
 You should now see the Siembol UI homepage. You can also try Storm UI to see running topologies:
 
-  * https://storm.local
+  * https://storm.siembol.local
 
 ### Enrichment tables
 


### PR DESCRIPTION
This PR aims at fixing the DNS resolution failures encountered on macOS with the quickstart guide.

The cause was the use of ingress FQDNs that don't share the same domain name (e.g. `storm.local` was not under `siembol.local`). This worked fine on Windows because all the ingress FQDNs are added as static IPs, but on macOS we use an actual DNS resolver that is registered only for the `siembol.local` domain name.