### PR TITLE
siembol parsing: changing logging level in some functions

### DIFF
--- a/alerting/alerting-core/pom.xml
+++ b/alerting/alerting-core/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>alerting</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/alerting/alerting-spark/pom.xml
+++ b/alerting/alerting-spark/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>alerting</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jackson-databind</artifactId>

--- a/alerting/alerting-storm/pom.xml
+++ b/alerting/alerting-storm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>alerting</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/alerting/pom.xml
+++ b/alerting/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <modules>
         <module>alerting-core</module>

--- a/config-editor/config-editor-core/pom.xml
+++ b/config-editor/config-editor-core/pom.xml
@@ -9,13 +9,13 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>config-editor</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/config-editor/config-editor-rest/pom.xml
+++ b/config-editor/config-editor-rest/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>config-editor</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencyManagement>
         <dependencies>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -67,22 +67,22 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>config-editor-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>config-editor-services</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>config-editor-sync</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>parsing-app</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>enriching-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>responding-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/config-editor/config-editor-services/pom.xml
+++ b/config-editor/config-editor-services/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>config-editor</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -41,32 +41,32 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>config-editor-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>parsing-app</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>enriching-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>responding-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/config-editor/config-editor-sync/pom.xml
+++ b/config-editor/config-editor-sync/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>config-editor</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>config-editor-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>parsing-app</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/config-editor/pom.xml
+++ b/config-editor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <modules>
         <module>config-editor-core</module>

--- a/deployment/storm-topology-manager/pom.xml
+++ b/deployment/storm-topology-manager/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencyManagement>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/enriching/enriching-core/pom.xml
+++ b/enriching/enriching-core/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>enriching</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/enriching/enriching-storm/pom.xml
+++ b/enriching/enriching-storm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>enriching</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>enriching-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/enriching/pom.xml
+++ b/enriching/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <modules>
         <module>enriching-core</module>

--- a/parsing/parsing-app/pom.xml
+++ b/parsing/parsing-app/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>parsing</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>parsing-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/parsing/parsing-app/src/main/java/uk/co/gresearch/siembol/parsers/application/parsing/ParsingApplicationParser.java
+++ b/parsing/parsing-app/src/main/java/uk/co/gresearch/siembol/parsers/application/parsing/ParsingApplicationParser.java
@@ -122,7 +122,7 @@ public abstract class ParsingApplicationParser implements Serializable {
             }
             return ret;
         } catch (Exception e) {
-            LOG.error(ERROR_MESSAGE, name, new String(message), metadata, ExceptionUtils.getMessage(e));
+            LOG.debug(ERROR_MESSAGE, name, new String(message), metadata, ExceptionUtils.getMessage(e));
             ret.add(new ParsingApplicationResult(errorTopic, getErrorMessage(e, sourceType, message)));
             return ret;
         }

--- a/parsing/parsing-app/src/main/java/uk/co/gresearch/siembol/parsers/application/parsing/RoutingParsingApplicationParser.java
+++ b/parsing/parsing-app/src/main/java/uk/co/gresearch/siembol/parsers/application/parsing/RoutingParsingApplicationParser.java
@@ -47,7 +47,7 @@ public class RoutingParsingApplicationParser extends ParsingApplicationParser {
                     || !parsedMsg.containsKey(routingMessageField)) {
                 String errorMsg = String.format(MISSING_ROUTER_FIELDS,
                         routingConditionField, routingMessageField, parsedMsg.toString());
-                LOG.error(errorMsg);
+                LOG.debug(errorMsg);
                 routerResult.setException(new IllegalStateException(errorMsg));
                 ret.add(routerResult);
                 continue; //NOTE: we try the next message that could be valid

--- a/parsing/parsing-core/pom.xml
+++ b/parsing/parsing-core/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>parsing</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/extractors/JsonExtractor.java
+++ b/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/extractors/JsonExtractor.java
@@ -78,7 +78,7 @@ public class JsonExtractor extends ParserExtractor {
         } catch (Exception e) {
             String errorMessage = String.format("Error during extracting json:%s\n Exception: %s",
                     message, ExceptionUtils.getStackTrace(e));
-            LOG.error(errorMessage);
+            LOG.debug(errorMessage);
             if (shouldThrowExceptionOnError()) {
                 throw new IllegalStateException(errorMessage);
             }

--- a/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/generic/SiembolGenericParser.java
+++ b/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/generic/SiembolGenericParser.java
@@ -46,7 +46,7 @@ public class SiembolGenericParser implements SiembolParser {
             return parsed.isEmpty() ? new ArrayList<>() : Arrays.asList(parsed);
         } catch (Exception e) {
             String errorMessage = String.format(PARSING_ERROR_MSG, originalMessage, ExceptionUtils.getStackTrace(e));
-            LOG.error(errorMessage);
+            LOG.debug(errorMessage);
             throw new IllegalStateException(errorMessage, e);
         }
     }

--- a/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/netflow/SiembolNetflowParser.java
+++ b/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/netflow/SiembolNetflowParser.java
@@ -69,7 +69,7 @@ public class SiembolNetflowParser implements SiembolParser {
         } catch (Exception e) {
             String errorMessage = String.format("Unable to parse message: %s",
                     Base64.getEncoder().encodeToString(bytes));
-            LOG.error(errorMessage, e);
+            LOG.debug(errorMessage, e);
             throw new IllegalStateException(errorMessage, e);
         }
 

--- a/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/syslog/SiembolSyslogParser.java
+++ b/parsing/parsing-core/src/main/java/uk/co/gresearch/siembol/parsers/syslog/SiembolSyslogParser.java
@@ -124,7 +124,7 @@ public class SiembolSyslogParser implements SiembolParser {
                     .collect(Collectors.toList());
         } catch (Exception e) {
             String errorMessage = String.format("Unable to parse message: %s", originalMessage);
-            LOG.error(errorMessage, e);
+            LOG.debug(errorMessage, e);
             throw new IllegalStateException(errorMessage, e);
         }
     }

--- a/parsing/parsing-storm/pom.xml
+++ b/parsing/parsing-storm/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>parsing</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>parsing-app</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/parsing/pom.xml
+++ b/parsing/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <modules>
         <module>parsing-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>uk.co.gresearch.siembol</groupId>
     <artifactId>siembol</artifactId>
     <name>siembol</name>
-    <version>2.2.7-SNAPSHOT</version>
+    <version>2.2.8-SNAPSHOT</version>
     <description>A scalable, advanced security analytics framework based on open-source big data technologies.</description>
     <inceptionYear>2019</inceptionYear>
     <url>https://siembol.io/</url>

--- a/responding/pom.xml
+++ b/responding/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <modules>
         <module>responding-core</module>

--- a/responding/responding-core/pom.xml
+++ b/responding/responding-core/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>responding</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -35,12 +35,12 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>alerting-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/responding/responding-stream/pom.xml
+++ b/responding/responding-stream/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>responding</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencyManagement>
         <dependencies>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>siembol-common</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>uk.co.gresearch.siembol</groupId>
             <artifactId>responding-core</artifactId>
-            <version>2.2.7-SNAPSHOT</version>
+            <version>2.2.8-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/siembol-common/pom.xml
+++ b/siembol-common/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>uk.co.gresearch.siembol</groupId>
         <artifactId>siembol</artifactId>
-        <version>2.2.7-SNAPSHOT</version>
+        <version>2.2.8-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
We would like to clean error logs from wrongly configured parsers. These messages with exceptions are exported to parsing error topic without logging into supervisors.