### PR TITLE
[ARCHIVING] Fix website URLs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-siembol.io

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,8 @@
 
 current_version:  1.1.0
 name: Siembol
+url: "https://g-research.github.io"
+baseurl: "/siembol"
 
 # Main Logo
 # -------------------------
@@ -52,7 +54,7 @@ features_thumbs:
 # Blockquote
 # -------------------------
 
-blockquote: 
+blockquote:
    text: "We develop online marketing solutions that help enterprises accurately identify the consumers that truly need their services."
    tagline: "Serving the community since 2014"
    button_text: "Read More"
@@ -70,7 +72,7 @@ services:
    description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magni tenetur officiis vel aspernatur. Quidem eligendi sequi veritatis vel recusandae porro maxime corporis id, deleniti harum alias asperiores soluta unde aliquam."
  - title: "UI/UX Design"
    icon: "magic"
-   description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magni tenetur officiis vel aspernatur. Quidem eligendi sequi veritatis vel recusandae porro maxime corporis id, deleniti harum alias asperiores soluta unde aliquam."      
+   description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magni tenetur officiis vel aspernatur. Quidem eligendi sequi veritatis vel recusandae porro maxime corporis id, deleniti harum alias asperiores soluta unde aliquam."
 
 # Work Mosaic
 # -------------------------
@@ -95,7 +97,7 @@ work_thumbs:
  - title: "Officiis Aspernatur"
    description: "Fugit aut earum in sit, placeat quis consequatur."
    url: "#_"
-   image: "/media/img/work-05.jpg"   
+   image: "/media/img/work-05.jpg"
  - title: "Soluta Asperiores"
    description: "Fugit aut earum in sit, placeat quis consequatur."
    url: "#_"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,6 @@
 
 current_version:  1.1.0
 name: Siembol
-url: "https://g-research.github.io"
 baseurl: "/siembol"
 
 # Main Logo

--- a/docs/_includes/article.html
+++ b/docs/_includes/article.html
@@ -1,16 +1,16 @@
 <section id="news" class="section-content main-background-color">
-    <img class="hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+    <img class="hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
     <div class="container padding-top-50 padding-bottom-50">
         <div class="row">
             <div class="col-lg-12">
                 <h1 class="text-center">{{ page.title }}</h1>
                 <hr class="margin-bottom-30">
-                <div class="article-image article-image-container-single" style="background: center no-repeat url(/media/news/title/{{ page.image }});"></div>
+                <div class="article-image article-image-container-single" style="background: center no-repeat url({{ '/media/news/title/' | append: page.image | relative_url }});"></div>
                 {{ page.content }}
             </div>
         </div>
     </div>
 
-    <img class="bottom-diagonal hidden-xs hidden-sm" src="/media/img/bottom-diagonal.png" alt="">
+    <img class="bottom-diagonal hidden-xs hidden-sm" src="{{ '/media/img/bottom-diagonal.png' | relative_url }}" alt="">
 </section>

--- a/docs/_includes/contact.html
+++ b/docs/_includes/contact.html
@@ -1,7 +1,7 @@
 
 
 		<section class="section-content main-background-color">
-			<img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+			<img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 			<div class="container padding-top-50 padding-bottom-100">
 				<div class="row">

--- a/docs/_includes/features.html
+++ b/docs/_includes/features.html
@@ -1,5 +1,5 @@
 	<section id="features" class="section-content main-background-color">
-		<img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+		<img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 		<div class="container padding-top-50 padding-bottom-50">
 			<div class="row">
@@ -41,5 +41,5 @@
 			</div>
 		</div>
 
-		<img class="bottom-diagonal hidden-xs hidden-sm" src="/media/img/bottom-diagonal.png" alt="">
+		<img class="bottom-diagonal hidden-xs hidden-sm" src="{{ '/media/img/bottom-diagonal.png' | relative_url }}" alt="">
 	</section>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,10 +2,10 @@
 <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
 <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 
-<script type="text/javascript" src="/js/respond.min.js"></script>
-<script type="text/javascript" src="/js/retina.min.js"></script>
-<script type="text/javascript" src="/js/skrollr.min.js"></script>
-<script type="text/javascript" src="/js/jquery.hidenavbaronscroll.js"></script>
+<script type="text/javascript" src="{{ '/js/respond.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/js/retina.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/js/skrollr.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/js/jquery.hidenavbaronscroll.js' | relative_url }}"></script>
 
 
-<script src="/js/main.js"></script>
+<script src="{{ '/js/main.js' | relative_url }}"></script>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -6,7 +6,7 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-<link rel="icon" type="image/png" href="icons/favicon.png">
+<link rel="icon" type="image/png" href="{{ 'icons/favicon.png' | relative_url }}">
 
 <!-- Bootstrap -->
 <link rel="stylesheet" type='text/css' href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
@@ -19,29 +19,29 @@
 <link rel='stylesheet' type='text/css' href='https://fonts.googleapis.com/css?family=Varela+Round'>
 
 <!-- Main Stylesheet -->
-<link rel="stylesheet" type='text/css' href="/css/main.css">
+<link rel="stylesheet" type='text/css' href="{{ '/css/main.css' | relative_url }}">
 
 <!-- Custom Stylesheet -->
-<link rel="stylesheet" type='text/css' href="/css/custom.css">
+<link rel="stylesheet" type='text/css' href="{{ '/css/custom.css' | relative_url }}">
 
 <!-- News Stylesheet -->
-<link rel="stylesheet" type='text/css' href="/css/news.css">
+<link rel="stylesheet" type='text/css' href="{{ '/css/news.css' | relative_url }}">
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
-     <script src="/js/html5shiv.js"></script>
-     <script src="/js/respond.min.js"></script>
+     <script src="{{ '/js/html5shiv.js' | relative_url }}"></script>
+     <script src="{{ '/js/respond.min.js' | relative_url }}"></script>
 <![endif]-->
 
 <!-- Favicons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="icons/apple-touch-icon-144-precomposed.png">
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="icons/apple-touch-icon-114-precomposed.png">
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="icons/apple-touch-icon-72-precomposed.png">
-<link rel="apple-touch-icon-precomposed" href="icons/apple-touch-icon-57-precomposed.png">
-<link rel="shortcut icon" href="icons/favicon.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ 'icons/apple-touch-icon-144-precomposed.png' | relative_url }}">
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ 'icons/apple-touch-icon-114-precomposed.png' | relative_url }}">
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ 'icons/apple-touch-icon-72-precomposed.png' | relative_url }}">
+<link rel="apple-touch-icon-precomposed" href="{{ 'icons/apple-touch-icon-57-precomposed.png' | relative_url }}">
+<link rel="shortcut icon" href="{{ 'icons/favicon.png' | relative_url }}">
 
 <!-- Modernizer -->
-<script src="/js/modernizr-2.6.2.min.js"></script>
+<script src="{{ '/js/modernizr-2.6.2.min.js' | relative_url }}"></script>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q36KCFXPV4"></script>

--- a/docs/_includes/join-us.html
+++ b/docs/_includes/join-us.html
@@ -1,5 +1,5 @@
 <section id="stay-tuned" class="section-content">
-    <img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+    <img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
     <div class="container padding-top-100 padding-bottom-100">
         <div class="row">

--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -10,13 +10,13 @@
 						<span class="icon-bar"></span>
 					</button>
 
-					<a class="navbar-brand" href="/">
+					<a class="navbar-brand" href="{{ '/' | relative_url }}">
 						<div class="visible-lg visible-md logo">
-							<img src="{{ site.logo_regular }}" alt="{{ site.name }} Logo">
+							<img src="{{ site.logo_regular | relative_url }}" alt="{{ site.name }} Logo">
 						</div>
 
 						<div class="visible-sm visible-xs">
-							<img src="{{ site.logo_small_devices }}" alt="{{ site.name }} Logo">
+							<img src="{{ site.logo_small_devices | relative_url }}" alt="{{ site.name }} Logo">
 						</div>
 					</a>
 				</div>
@@ -24,13 +24,13 @@
 				<div class="navbar-collapse collapse">
 					<ul class="nav navbar-nav navbar-right">
 						{% for link in site.navbar_links %}
-						<li><a href="{{ link.url }}">{{ link.title }}</a></li>
+						<li><a href="{{ link.url | relative_url }}">{{ link.title }}</a></li>
 						{% endfor %}
 					</ul>
 				</div>
 			</div>
 		</div>
 
-		<img class="bottom-diagonal-navbar hidden-xs hidden-sm" src="/media/img/navbar-diagonal-{{ site.navbar_color }}.png" alt="">
+		<img class="bottom-diagonal-navbar hidden-xs hidden-sm" src="{{ '/media/img/navbar-diagonal-' | append: site.navbar_color | append: '.png' | relative_url }}" alt="">
 	</div>
 	<!-- End Navbar -->

--- a/docs/_includes/news.html
+++ b/docs/_includes/news.html
@@ -1,5 +1,5 @@
 	<section id="news" class="section-content main-background-color">
-		<img class="hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+		<img class="hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 		<div class="container padding-top-50 padding-bottom-50">
 			<div class="row">
@@ -12,12 +12,12 @@
 						<div class="row">
 							{% for article in site.posts %}
 							<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12 article">
-								<a href="{{ article.url }}">
-									<div class="article-image article-image-container" style="background: center no-repeat url(/media/news/title/{{ article.image }});"></div>
+								<a href="{{ article.url | relative_url }}">
+									<div class="article-image article-image-container" style="background: center no-repeat url({{ '/media/news/title/' | append: article.image | relative_url }});"></div>
 								</a>
-								<a href="{{ article.url }}"><h3><b>{{ article.title }}</b></h3></a>
+								<a href="{{ article.url | relative_url }}"><h3><b>{{ article.title }}</b></h3></a>
 								<p>{{ article.excerpt }}</p>
-								<a href="{{ article.url }}"><span>Read More</span></a>
+								<a href="{{ article.url | relative_url }}"><span>Read More</span></a>
 							</div>
 							{% endfor %}
 						</div>
@@ -27,5 +27,5 @@
 			</div>
 		</div>
 
-		<img class="bottom-diagonal hidden-xs hidden-sm" src="/media/img/bottom-diagonal.png" alt="">
+		<img class="bottom-diagonal hidden-xs hidden-sm" src="{{ '/media/img/bottom-diagonal.png' | relative_url }}" alt="">
 	</section>

--- a/docs/_includes/pricing-tables.html
+++ b/docs/_includes/pricing-tables.html
@@ -1,5 +1,5 @@
 		<section id="pricing-tables" class="section-content main-background-color">
-			<img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+			<img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 			<div class="container padding-top-50 padding-bottom-100">
 				<div class="row">
@@ -65,5 +65,5 @@
 				</div>
 			</div>
 
-			<img class="bottom-diagonal hidden-xs hidden-sm" src="/media/img/bottom-diagonal.png" alt="">
+			<img class="bottom-diagonal hidden-xs hidden-sm" src="{{ '/media/img/bottom-diagonal.png' | relative_url }}" alt="">
 		</section>

--- a/docs/_includes/services.html
+++ b/docs/_includes/services.html
@@ -1,5 +1,5 @@
 		<section id="services" class="section-content main-background-color">
-			<img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+			<img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 			<div class="container">
 				<div class="row">
@@ -31,5 +31,5 @@
 				</div>
 			</div>
 
-			<img class="bottom-diagonal hidden-xs hidden-sm" src="/media/img/bottom-diagonal.png" alt="">
+			<img class="bottom-diagonal hidden-xs hidden-sm" src="{{ '/media/img/bottom-diagonal.png' | relative_url }}" alt="">
 		</section>

--- a/docs/_includes/work-gallery.html
+++ b/docs/_includes/work-gallery.html
@@ -1,5 +1,5 @@
 		<section id="work" class="section-content secondary-background-color">
-			<img class="top-diagonal hidden-xs hidden-sm" src="/media/img/top-diagonal.png" alt="">
+			<img class="top-diagonal hidden-xs hidden-sm" src="{{ '/media/img/top-diagonal.png' | relative_url }}" alt="">
 
 			<div class="container padding-top-100 padding-bottom-100">
 				<div class="row">
@@ -11,7 +11,7 @@
 							<ul class="mosaic-list">
 								{% for thumbs in site.work_thumbs %}
 								<li class="mosaic-gallery-item col-lg-3 col-ms-3 col-sm-6">
-									<img src="{{ thumbs.image }}" alt="{{ thumbs.title }}">
+									<img src="{{ thumbs.image | relative_url }}" alt="{{ thumbs.title }}">
 									<div class="mosaic-thumb-overlay">
 										<a href="{{ thumbs.url }}">
 											<div class="mosaic-thumb-detail">


### PR DESCRIPTION
**Context:**

The project website is currently hosted on GitHub Pages using the custom domain [siembol.io](https://siembol.io/). As the project is scheduled for archiving, we will no longer maintain this domain. To ensure continued access to the website, we need to transition to hosting it on the default GitHub Pages URL: [https://g-research.github.io/siembol](https://g-research.github.io/siembol).

## Changes Made:

- **Update URLs:** All URLs have been updated to use relative paths instead of absolute paths. This change ensures that links remain functional regardless of the use of a `baseurl` or not.
- **Configuration Update:** A `baseurl` has been added to the Jekyll configuration. This addition supports the use of the default GitHub Pages URL without breaking existing links.
- **Disable Custom Domain:** the `CNAME` file has been removed to disable the use of the custom domain.

## Preview

[Preview on my fork](https://naskio.github.io/siembol/)

## ToDo:
- [ ] Once we merge this PR, we need to change the domain config of `siembol.io` to redirect to https://g-research.github.io/siembol.